### PR TITLE
Null terminate string before using it.

### DIFF
--- a/src/utils/aa-tty.c
+++ b/src/utils/aa-tty.c
@@ -107,5 +107,6 @@ main (int argc, char * const argv[])
             else
                 aa_strerr_diefu2sys (2, "read ", file);
         }
+        name[r] = '\0';
     }
 }


### PR DESCRIPTION
aa_bs_flush uses strlen, but openreadnclose reads bytes, not c-strings.

Without this, aa-tty was sometimes printing extra junk bytes after the filename which confused other programs like redirectfd (file not found errors and such)
